### PR TITLE
Add T7XC flavor.

### DIFF
--- a/core/arch/arm/plat-stm32mp1/conf.mk
+++ b/core/arch/arm/plat-stm32mp1/conf.mk
@@ -13,13 +13,15 @@ flavor_dts_file-157F_ED1 = stm32mp157f-ed1.dts
 flavor_dts_file-157F_EV1 = stm32mp157f-ev1.dts
 flavor_dts_file-135F_DK = stm32mp135f-dk.dts
 flavor_dts_file-153C_BRICK = stm32mp153c-brick-mx.dts
+flavor_dts_file-153C_T7XC = stm32mp153c-t7xc-mx.dts
 
 flavorlist-512M = $(flavor_dts_file-157A_DK1) \
 		  $(flavor_dts_file-157C_DK2) \
 		  $(flavor_dts_file-157D_DK1) \
 		  $(flavor_dts_file-157F_DK2) \
 		  $(flavor_dts_file-135F_DK) \
-		  $(flavor_dts_file-153C_BRICK)
+		  $(flavor_dts_file-153C_BRICK) \
+		  $(flavor_dts_file-153C_T7XC)
 
 flavorlist-1G = $(flavor_dts_file-157A_ED1) \
 		$(flavor_dts_file-157A_EV1) \
@@ -42,7 +44,8 @@ flavorlist-MP15 = $(flavor_dts_file-157A_DK1) \
 		  $(flavor_dts_file-157C_EV1) \
 		  $(flavor_dts_file-157F_ED1) \
 		  $(flavor_dts_file-157F_EV1) \
-		  $(flavor_dts_file-153C_BRICK)
+		  $(flavor_dts_file-153C_BRICK) \
+		  $(flavor_dts_file-153C_T7XC)
 
 flavorlist-MP13 = $(flavor_dts_file-135F_DK)
 


### PR DESCRIPTION
Just a small change to add the T7XC flavor to the build.   Since `optee-os` and `arm-trusted-firmware` control all the clocking I think we should have separate builds for both the M7XC and T7XC
